### PR TITLE
Fix language-specific data not loading on app restart

### DIFF
--- a/app/converse/page.tsx
+++ b/app/converse/page.tsx
@@ -12,7 +12,7 @@ import { MessageCircle, Mic, MicOff, Volume2, Play, Pause, Square, Waves, Settin
 export default function ConversePage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
   
   const [currentSession, setCurrentSession] = useState<ConversationSession | null>(null);
   const [conversationState, setConversationState] = useState<'idle' | 'listening' | 'processing' | 'speaking'>('idle');

--- a/app/listen/page.tsx
+++ b/app/listen/page.tsx
@@ -12,8 +12,8 @@ import Link from "next/link";
 export default function ListenPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
-  const [audioService] = useState(() => new UnifiedAudioService(config.voiceOptions));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const audioService = new UnifiedAudioService(config.voiceOptions);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -12,7 +12,7 @@ import { Plus, Edit2, Trash2, Tag, Filter, BookOpen, Volume2, Mic } from "lucide
 export default function ManagePage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
   
   const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
   const [searchTerm, setSearchTerm] = useState("");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function HomePage() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
   const [stats, setStats] = useState({ total: 0, reviewed: 0, categories: 0 });
   const [isClient, setIsClient] = useState(false);
 

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -10,7 +10,7 @@ import Link from "next/link";
 export default function ReviewPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);

--- a/app/speak/page.tsx
+++ b/app/speak/page.tsx
@@ -12,8 +12,8 @@ import Link from "next/link";
 export default function SpeakPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const [localStorage] = useState(() => new UnifiedLocalStorage(`${config.code}-flashcards`));
-  const [audioService] = useState(() => new UnifiedAudioService(config.voiceOptions));
+  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const audioService = new UnifiedAudioService(config.voiceOptions);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);


### PR DESCRIPTION
When users log back into the PWA and it defaults to Indonesian, the app was showing Chinese categories and flashcards until they switched tabs.

The issue was that localStorage and audioService instances were created once using useState with the initial config, preventing them from updating when the language changed.

Fixed by removing useState wrapper and creating new instances directly:
- Changed `const [localStorage] = useState(() => new UnifiedLocalStorage(...))`
- To `const localStorage = new UnifiedLocalStorage(...)`
- Applied to all pages: manage, listen, speak, review, converse, and home
- Also fixed audioService instances in listen and speak pages

This ensures the correct language data loads immediately when the app opens.

🤖 Generated with [Claude Code](https://claude.ai/code)