### PR TITLE
Fix localStorage recreation issue causing navigation problems

### DIFF
--- a/app/converse/page.tsx
+++ b/app/converse/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { useLanguage } from "@/shared/contexts/LanguageContext";
@@ -12,7 +12,7 @@ import { MessageCircle, Mic, MicOff, Volume2, Play, Pause, Square, Waves, Settin
 export default function ConversePage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
   
   const [currentSession, setCurrentSession] = useState<ConversationSession | null>(null);
   const [conversationState, setConversationState] = useState<'idle' | 'listening' | 'processing' | 'speaking'>('idle');
@@ -37,7 +37,7 @@ export default function ConversePage() {
     
     // Initialize speech APIs
     initializeSpeechAPIs();
-  }, [localStorage]);
+  }, [config.code]);
 
   const initializeSpeechAPIs = useCallback(() => {
     try {

--- a/app/listen/page.tsx
+++ b/app/listen/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { useLanguage } from "@/shared/contexts/LanguageContext";
 import { usePwa } from "@/shared/contexts/PwaContext";
@@ -12,8 +12,8 @@ import Link from "next/link";
 export default function ListenPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
-  const audioService = new UnifiedAudioService(config.voiceOptions);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
+  const audioService = useMemo(() => new UnifiedAudioService(config.voiceOptions), [config.voiceOptions]);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { useLanguage } from "@/shared/contexts/LanguageContext";
 import { usePwa } from "@/shared/contexts/PwaContext";
@@ -12,7 +12,7 @@ import { Plus, Edit2, Trash2, Tag, Filter, BookOpen, Volume2, Mic } from "lucide
 export default function ManagePage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
   
   const [flashcards, setFlashcards] = useState<Flashcard[]>([]);
   const [searchTerm, setSearchTerm] = useState("");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { UnifiedTranslationService } from "@/shared/utils/translationService";
@@ -28,7 +28,7 @@ export default function HomePage() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [categories, setCategories] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | undefined>(undefined);
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
   const [stats, setStats] = useState({ total: 0, reviewed: 0, categories: 0 });
   const [isClient, setIsClient] = useState(false);
 
@@ -51,7 +51,7 @@ export default function HomePage() {
       reviewed: reviewedCards,
       categories: loadedCategories.length
     });
-  }, [localStorage, isClient]);
+  }, [isClient, config.code]);
 
   // Validate input based on language
   const isValidLanguageInput = useCallback((text: string): boolean => {

--- a/app/review/page.tsx
+++ b/app/review/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { useLanguage } from "@/shared/contexts/LanguageContext";
 import { usePwa } from "@/shared/contexts/PwaContext";
@@ -10,7 +10,7 @@ import Link from "next/link";
 export default function ReviewPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);

--- a/app/speak/page.tsx
+++ b/app/speak/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
 import { useLanguage } from "@/shared/contexts/LanguageContext";
 import { usePwa } from "@/shared/contexts/PwaContext";
@@ -12,8 +12,8 @@ import Link from "next/link";
 export default function SpeakPage() {
   const { config, currentLanguage } = useLanguage();
   const { isPwa } = usePwa();
-  const localStorage = new UnifiedLocalStorage(`${config.code}-flashcards`);
-  const audioService = new UnifiedAudioService(config.voiceOptions);
+  const localStorage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
+  const audioService = useMemo(() => new UnifiedAudioService(config.voiceOptions), [config.voiceOptions]);
   
   const [cards, setCards] = useState<Flashcard[]>([]);
   const [currentCardIndex, setCurrentCardIndex] = useState(0);


### PR DESCRIPTION
The previous fix created new localStorage instances on every render, which caused useEffect hooks to run continuously and broke navigation.

Fixed by using useMemo to memoize localStorage and audioService instances:
- Only recreate when config.code changes (language switch)
- Prevents unnecessary re-renders and effect executions
- Fixed dependency arrays to use config.code instead of localStorage
- Ensures proper data loading on language switch without breaking navigation

🤖 Generated with [Claude Code](https://claude.ai/code)