### PR TITLE
Add video imports to ChindoSpeak

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+OPENAI_API_KEY=sk-your-key-here
+
+# Optional translation providers
+BAIDU_APP_ID=your_app_id
+BAIDU_API_KEY=your_api_key
+GOOGLE_CLOUD_API_KEY=your_google_cloud_key

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ChindoSpeak - Unified Language Learning Platform
+# ChindoSpeak
 
-A unified Progressive Web App (PWA) architecture for language learning applications, supporting multiple languages with shared components and language-specific configurations.
+ChindoSpeak is a Progressive Web App for learning Mandarin Chinese and Indonesian with flashcards, listening practice, speaking review, drive mode, and short-form video imports.
 
 ## Architecture Overview
 
@@ -27,6 +27,12 @@ chindospeak/
 ```
 
 ## Key Features
+
+- **Learn from Video**: paste a TikTok, Instagram Reel, or YouTube Short and generate a transcript, translation, phrase drill, speaking prompt, and review-ready flashcards.
+- **Spaced Repetition Flashcards**: separate reading, listening, and speaking review levels.
+- **Listening and Speaking Practice**: practice saved cards with audio and speech recognition.
+- **Drive Mode**: hands-free review for cards that are due.
+- **Offline PWA**: installable mobile experience with local-first card storage.
 
 ### Unified Components
 - **PwaWrapper**: PWA installation handling
@@ -72,17 +78,24 @@ Unified text-to-speech system with:
    npm install
    ```
 
-2. Set up environment variables for translation services:
+2. Install local video tooling for the video import feature:
    ```bash
-   # For Chinese (Baidu Translate)
-   NEXT_PUBLIC_BAIDU_APP_ID=your_app_id
-   NEXT_PUBLIC_BAIDU_API_KEY=your_api_key
+   brew install yt-dlp ffmpeg
    ```
 
-3. Run the development server:
+3. Set up environment variables:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+   Add `OPENAI_API_KEY` to `.env.local` for video transcription, OCR, vocab extraction, and speaking prompts. Baidu and Google translation keys are optional.
+
+4. Run the development server:
    ```bash
    npm run dev
    ```
+
+5. Open [http://localhost:3000](http://localhost:3000).
 
 ## Adding a New Language
 
@@ -98,11 +111,13 @@ The original language-specific apps have been analyzed and their common componen
 
 ## Technology Stack
 
-- **Next.js 15** - React framework
+- **Next.js 16** - React framework
 - **TypeScript** - Type safety
 - **Tailwind CSS** - Styling
 - **PWA** - Offline capability
 - **Web Speech API** - Text-to-speech
+- **OpenAI Whisper + GPT-4o-mini** - Video transcription, OCR reconciliation, lesson generation
+- **yt-dlp + ffmpeg** - Local short-form video processing
 - **Multiple Translation APIs** - Baidu, MyMemory, Google (extensible)
 
 ## License

--- a/app/api/video/process/route.ts
+++ b/app/api/video/process/route.ts
@@ -1,0 +1,421 @@
+import { randomUUID } from "crypto";
+import { createReadStream } from "fs";
+import { access, mkdir, readFile, readdir, rm, unlink } from "fs/promises";
+import os from "os";
+import path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+
+const execFileAsync = promisify(execFile);
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+type LessonJson = {
+  language?: string;
+  cleanTranscript?: string;
+  transcriptNotes?: string;
+  translation?: string;
+  summary?: string;
+  speakingChallenge?: {
+    prompt?: string;
+    keywords?: string[];
+  };
+  vocab?: Array<{
+    word?: string;
+    pronunciation?: string;
+    meaning?: string;
+    example?: string;
+    note?: string;
+    sourcePhrase?: string;
+    usefulness?: string;
+    level?: string;
+  }>;
+  quiz?: Array<{
+    question?: string;
+    choices?: string[];
+    answer?: string;
+    explanation?: string;
+  }>;
+};
+
+export async function POST(req: NextRequest) {
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json(
+      { error: "Missing OPENAI_API_KEY in .env.local" },
+      { status: 500 },
+    );
+  }
+
+  const body = await req.json().catch(() => null);
+  const url = typeof body?.url === "string" ? body.url.trim() : "";
+
+  if (!url) {
+    return NextResponse.json({ error: "Paste a video URL first." }, { status: 400 });
+  }
+
+  const id = randomUUID();
+  const outputTemplate = path.join(os.tmpdir(), `${id}.%(ext)s`);
+  const audioPath = path.join(os.tmpdir(), `${id}.mp3`);
+  const frameDir = path.join(os.tmpdir(), `${id}-frames`);
+  let videoPath = "";
+  const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+
+  try {
+    videoPath = await downloadVideo(url, outputTemplate);
+    await extractAudio(videoPath, audioPath);
+    const subtitleText = await extractSubtitleText(openai, videoPath, frameDir).catch(() => "");
+
+    const transcription = await openai.audio.transcriptions.create({
+      file: createReadStream(audioPath),
+      model: "whisper-1",
+      response_format: "verbose_json",
+    });
+
+    const detectedLang =
+      "language" in transcription && typeof transcription.language === "string"
+        ? transcription.language
+        : "unknown";
+    const transcript = transcription.text?.trim() || "";
+
+    if (!transcript) {
+      throw new Error("Whisper did not find speech in this clip. Try a clearer or shorter video.");
+    }
+
+    const completion = await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      response_format: { type: "json_object" },
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a precise language learning assistant. Respond with valid JSON only.",
+        },
+        {
+          role: "user",
+          content: `This is a transcript from a short video. Whisper detected the language as "${detectedLang}". Use the transcript and subtitle OCR to determine the actual language if detection is ambiguous.
+
+Transcript:
+"""
+${transcript}
+"""
+
+Burned-in subtitle OCR from video frames, if available:
+"""
+${subtitleText || "No readable burned-in subtitles found."}
+"""
+
+Return JSON with this exact shape:
+{
+  "language": string,
+  "cleanTranscript": "corrected transcript with obvious ASR mistakes fixed, preserving the speaker's casual style",
+  "transcriptNotes": "briefly mention any uncertain correction, or empty string",
+  "translation": "full English translation",
+  "summary": "1-2 sentence cultural/contextual summary explaining slang, references, or subtext a learner would miss",
+  "speakingChallenge": {
+    "prompt": "a concrete speaking prompt asking the learner to talk about a similar situation using the target language",
+    "keywords": ["3-5 words or phrases from vocab/source phrases that the learner should try to use"]
+  },
+  "vocab": [
+    {
+      "word": "the word in original script",
+      "pronunciation": "learner-friendly pronunciation or romanization when useful",
+      "meaning": "English meaning",
+      "example": "short example sentence in original language",
+      "note": "slang/register/formality note, or empty string",
+      "sourcePhrase": "the exact phrase from the transcript where it appeared",
+      "usefulness": "why this is worth learning from this video",
+      "level": "slang" | "phrase" | "intermediate" | "basic-but-important"
+    }
+  ],
+  "quiz": [
+    {
+      "question": "natural multiple-choice question testing one specific word, phrase, or sentence chunk from the transcript",
+      "choices": ["choice A", "choice B", "choice C", "choice D"],
+      "answer": "exact correct choice text",
+      "explanation": "one sentence explaining the answer"
+    }
+  ]
+}
+
+Use the subtitle OCR as a correction signal when it clearly disagrees with Whisper, especially for slang, names, particles, Chinese characters, or Indonesian words that Whisper may have phonetically guessed. Do not copy OCR errors blindly; reconcile the most likely spoken transcript. Also use language plausibility: if Whisper produces a nonsensical phrase, fix it to the nearest common casual phrase instead of teaching the nonsense word. For Indonesian, phrases like "wampong lagi menang" or "lumpuh lagi menang" near a gambling/winning context are likely "mumpung lagi menang" ("since/while we're winning"). Never create a vocab card for a word unless you are confident it is real in context; if uncertain, put the uncertainty in transcriptNotes.
+
+Pick the 5 most useful vocab items for a learner with roughly second-grade fluency in the target language: they know many everyday words, but still need help with real conversations, school/work/domain nouns, common sentence chunks, slang, idioms, and culturally specific phrasing. Do not use a rigid basic-word filter. A "basic" word can be useful if it is likely new to a low-intermediate learner, important to the clip, or part of a reusable phrase. Strongly prioritize reusable chunks, collocations, slang, idioms, discourse markers, particles, culturally specific metaphors, and concrete domain nouns. For Indonesian, examples may include "gelas kosong", "jualan ke hotel-hotel", "dari sisi spesifikasi", "harus ngerti spesifikasi", "coba kamu ... dulu", "pengiriman", and concrete nouns like "karyawan" if useful. For Chinese, prioritize useful characters/words, chengyu, discourse particles, sentence patterns, slang, and culturally loaded phrases. If the clip includes English mixed into Indonesian or Chinese, include the English/code-switched phrase only if a learner in that language community genuinely needs it to understand natural speech. If a term is uncertain because the transcript may be imperfect, include that uncertainty in "note" instead of pretending. Create exactly 5 quiz questions total, and every question must test a specific keyword, phrase, discourse marker, pronoun/register choice, or sentence chunk from the transcript. Each quiz question must test a different target word or phrase; do not ask multiple questions about the same word unless the second question tests a meaningfully different reusable chunk. Make question wording natural and grammatically correct. Do not write awkward questions like "In 'pengalaman', what does it mean?" Instead write "What does 'pengalaman' mean here?", "In 'pengalaman pertama saya', what does 'pengalaman' mean?", "What does 'gelas kosong' imply in this clip?", or "Which phrase means 'keep playing'?" Do not ask generic comprehension questions like "what is the main theme?" because learners can already infer broad meaning. Hard rule: every quiz question must be based on words or phrases that appear in cleanTranscript, subtitle OCR, or a vocab sourcePhrase. Do not introduce new words that are not in the video. Make the quiz useful before the learner reads the vocab cards, so test recall and context rather than copying definitions directly.`,
+        },
+      ],
+    });
+
+    const rawContent = completion.choices[0]?.message.content || "{}";
+    const lesson = JSON.parse(rawContent) as LessonJson;
+    const rawVocab = Array.isArray(lesson.vocab)
+      ? lesson.vocab.map((item) => ({
+          word: item.word || "",
+          pronunciation: item.pronunciation || "",
+          meaning: item.meaning || "",
+          example: item.example || "",
+          note: item.note || "",
+          sourcePhrase: item.sourcePhrase || "",
+          usefulness: item.usefulness || "",
+          level: item.level || "",
+        }))
+      : [];
+    const vocab = rawVocab.filter((item) => item.word.trim()).slice(0, 5);
+    const speakingKeywords = getSpeakingKeywords(
+      lesson.speakingChallenge?.keywords,
+      vocab,
+    );
+
+    return NextResponse.json({
+      transcript,
+      subtitleText,
+      detectedLang,
+      language: lesson.language || detectedLang,
+      cleanTranscript: lesson.cleanTranscript || transcript,
+      transcriptNotes: lesson.transcriptNotes || "",
+      translation: lesson.translation || "",
+      summary: lesson.summary || "",
+      speakingChallenge: {
+        prompt:
+          lesson.speakingChallenge?.prompt ||
+          `In ${lesson.language || detectedLang}, respond to the situation in this video.`,
+        keywords: speakingKeywords,
+      },
+      vocab,
+      quiz: Array.isArray(lesson.quiz)
+        ? lesson.quiz.slice(0, 5).map((item) => ({
+            question: item.question || "",
+            choices: Array.isArray(item.choices) ? item.choices.filter(Boolean) : [],
+            answer: item.answer || "",
+            explanation: item.explanation || "",
+          }))
+        : [],
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: humanizeError(err) },
+      { status: 500 },
+    );
+  } finally {
+    await unlink(audioPath).catch(() => undefined);
+    if (videoPath) {
+      await unlink(videoPath).catch(() => undefined);
+    }
+    await rm(frameDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function downloadVideo(url: string, outputTemplate: string) {
+  const baseArgs = [
+    "--no-playlist",
+    "--max-filesize",
+    "80m",
+    "-f",
+    "bv*+ba/b",
+    "--merge-output-format",
+    "mp4",
+    "--print",
+    "after_move:filepath",
+    "-o",
+    outputTemplate,
+    url,
+  ];
+
+  try {
+    return await runYtDlp(baseArgs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const shouldTryBrowserCookies =
+      url.includes("instagram.com") ||
+      message.includes("This content isn't available") ||
+      message.includes("login") ||
+      message.includes("cookies");
+
+    if (!shouldTryBrowserCookies) {
+      throw err;
+    }
+
+    return await runYtDlp(["--cookies-from-browser", "chrome", ...baseArgs]);
+  }
+}
+
+async function runYtDlp(args: string[]) {
+  const { stdout } = await execFileAsync("yt-dlp", args, {
+    timeout: 60_000,
+    maxBuffer: 1024 * 1024 * 10,
+  });
+
+  const lines = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (await fileExists(line)) {
+      return line;
+    }
+  }
+
+  const downloadedPath = lines[lines.length - 1];
+
+  if (!downloadedPath) {
+    throw new Error("yt-dlp did not report a downloaded video path.");
+  }
+
+  return downloadedPath;
+}
+
+async function extractAudio(videoPath: string, audioPath: string) {
+  await execFileAsync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-y",
+      "-i",
+      videoPath,
+      "-vn",
+      "-acodec",
+      "libmp3lame",
+      "-q:a",
+      "4",
+      audioPath,
+    ],
+    { timeout: 45_000, maxBuffer: 1024 * 1024 * 10 },
+  );
+}
+
+async function extractSubtitleText(openai: OpenAI, videoPath: string, frameDir: string) {
+  await mkdir(frameDir, { recursive: true });
+  const framePattern = path.join(frameDir, "subtitle-%02d.jpg");
+
+  await execFileAsync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-y",
+      "-i",
+      videoPath,
+      "-vf",
+      "fps=1/2,crop=iw:ih*0.55:0:ih*0.45,scale=960:-1",
+      "-frames:v",
+      "16",
+      "-q:v",
+      "4",
+      framePattern,
+    ],
+    { timeout: 45_000, maxBuffer: 1024 * 1024 * 10 },
+  );
+
+  const framePaths = (await readdir(frameDir))
+    .filter((file) => file.endsWith(".jpg"))
+    .sort()
+    .slice(0, 16)
+    .map((file) => path.join(frameDir, file));
+
+  if (!framePaths.length) {
+    return "";
+  }
+
+  const imageContent = await Promise.all(
+    framePaths.map(async (framePath) => ({
+      type: "image_url" as const,
+      image_url: {
+        url: `data:image/jpeg;base64,${(await readFile(framePath)).toString("base64")}`,
+        detail: "low" as const,
+      },
+    })),
+  );
+
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    response_format: { type: "json_object" },
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are an OCR assistant for short-form video subtitles. Respond with valid JSON only.",
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Read only burned-in subtitle text from these cropped video frames. Ignore UI, usernames, buttons, watermarks, reactions, and captions outside the spoken subtitle area.
+
+Return JSON:
+{
+  "subtitleText": "unique subtitle lines in likely spoken order, deduplicated"
+}
+
+Preserve original script, slang, punctuation, and casual spelling. If no subtitles are readable, return an empty string.`,
+          },
+          ...imageContent,
+        ],
+      },
+    ],
+  });
+
+  const rawContent = completion.choices[0]?.message.content || "{}";
+  const parsed = JSON.parse(rawContent) as { subtitleText?: string };
+  return parsed.subtitleText?.trim() || "";
+}
+
+function getSpeakingKeywords(
+  modelKeywords: string[] | undefined,
+  vocab: Array<{ word: string; sourcePhrase: string; level: string }>,
+) {
+  const basicWords = new Set(["bisa", "main", "menang", "kalah"]);
+  const candidates = [
+    ...(Array.isArray(modelKeywords) ? modelKeywords : []),
+    ...vocab
+      .filter((item) => ["slang", "phrase", "intermediate"].includes(item.level))
+      .map((item) => item.sourcePhrase || item.word),
+  ];
+
+  return Array.from(
+    new Set(
+      candidates
+        .map((keyword) => keyword.trim())
+        .filter((keyword) => keyword && !basicWords.has(keyword.toLowerCase())),
+    ),
+  ).slice(0, 5);
+}
+
+function humanizeError(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (message.includes("ENOENT") && message.includes("yt-dlp")) {
+    return "yt-dlp is not installed. Run: brew install yt-dlp ffmpeg";
+  }
+
+  if (message.includes("ENOENT") && (message.includes("ffmpeg") || message.includes("ffprobe"))) {
+    return "ffmpeg is missing or unavailable. Run: brew install ffmpeg";
+  }
+
+  if (message.includes("Command failed") || message.includes("Unable to")) {
+    return `Could not download this video. If this is Instagram, open the Reel in Chrome while logged in, then try again. Otherwise try a public YouTube Short backup. Details: ${message}`;
+  }
+
+  if (message.includes("timed out")) {
+    return "The download took too long. Try a shorter clip for the demo.";
+  }
+
+  return message || "Processing failed.";
+}
+
+async function fileExists(filePath: string) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -58,6 +58,9 @@ export default function Navigation() {
             <NavLink href="/speak" current={pathname === "/speak"} config={config}>
               {config.ui.navigation.speak}
             </NavLink>
+            <NavLink href="/video" current={pathname === "/video"} config={config}>
+              Video
+            </NavLink>
             <NavLink href="/manage" current={pathname === "/manage"} config={config}>
               {config.ui.navigation.manage}
             </NavLink>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "ChindoSpeak - Language Learning",
-  description: "Learn Chinese and Indonesian with spaced repetition flashcards",
+  description: "Learn from short videos, flashcards, listening practice, and speaking review",
   manifest: "/manifest.json",
   icons: {
     icon: '/favicon.ico',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import { usePwa } from "@/shared/contexts/PwaContext";
 import PwaWrapper from "@/shared/components/PwaWrapper";
 import { Flashcard, Category, StreakData, DailyChallenge, DailyActivity } from "@/shared/types";
 import isChinese from 'is-chinese';
-import { PlusCircle, Car, Headphones, Mic, BookOpen } from 'lucide-react';
+import { PlusCircle, Car, Headphones, Mic, BookOpen, Clapperboard } from 'lucide-react';
 import Link from 'next/link';
 import StreakDisplay from '@/shared/components/StreakDisplay';
 import StreakWarningBanner from '@/shared/components/StreakWarningBanner';
@@ -108,6 +108,17 @@ function LandingPage() {
                 <div>
                   <h3 className="font-semibold text-gray-900 dark:text-white">Smart Flashcards</h3>
                   <p className="text-sm text-gray-600 dark:text-gray-400">Spaced repetition for long-term retention</p>
+                </div>
+              </div>
+
+              {/* Video Import Feature */}
+              <div className="flex items-start gap-4">
+                <div className="w-10 h-10 rounded-lg bg-violet-100 dark:bg-violet-900 flex items-center justify-center flex-shrink-0">
+                  <Clapperboard className="w-5 h-5 text-violet-600 dark:text-violet-400" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-gray-900 dark:text-white">Learn from Videos</h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">Turn short clips into review-ready cards</p>
                 </div>
               </div>
 
@@ -379,6 +390,28 @@ function AppContent() {
             primaryColor={config.theme.primary}
           />
         )}
+
+        <Link
+          href="/video"
+          className="block rounded-xl border border-violet-200 bg-violet-50 p-5 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md dark:border-violet-900 dark:bg-violet-950"
+        >
+          <div className="flex items-start gap-4">
+            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-violet-600 text-white">
+              <Clapperboard className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-violet-700 dark:text-violet-200">
+                New
+              </p>
+              <h2 className="text-lg font-bold text-gray-950 dark:text-white">
+                Learn from a short video
+              </h2>
+              <p className="mt-1 text-sm leading-5 text-gray-600 dark:text-gray-300">
+                Paste a Reel, TikTok, or Short and save useful words straight into your {config.name} deck.
+              </p>
+            </div>
+          </div>
+        </Link>
 
         {/* Create Form Section */}
         <div className="bg-gray-50 dark:bg-gray-800 p-6 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700">

--- a/app/video/page.tsx
+++ b/app/video/page.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+import { v4 as uuidv4 } from "uuid";
+import { ArrowLeft, BookOpen, Check, Clapperboard, Loader2, Save, Sparkles } from "lucide-react";
+import { useLanguage } from "@/shared/contexts/LanguageContext";
+import { UnifiedLocalStorage } from "@/shared/utils/localStorage";
+import { Category, Flashcard } from "@/shared/types";
+
+type VocabItem = {
+  word: string;
+  pronunciation: string;
+  meaning: string;
+  example: string;
+  note?: string;
+  sourcePhrase?: string;
+  usefulness?: string;
+  level?: string;
+};
+
+type QuizItem = {
+  question: string;
+  choices: string[];
+  answer: string;
+  explanation: string;
+};
+
+type VideoLesson = {
+  transcript: string;
+  subtitleText?: string;
+  cleanTranscript: string;
+  transcriptNotes: string;
+  detectedLang: string;
+  language: string;
+  translation: string;
+  summary: string;
+  speakingChallenge?: {
+    prompt: string;
+    keywords: string[];
+  };
+  vocab: VocabItem[];
+  quiz: QuizItem[];
+};
+
+const IMPORT_CATEGORY = "Video Imports";
+
+export default function VideoPage() {
+  const { config } = useLanguage();
+  const storage = useMemo(() => new UnifiedLocalStorage(`${config.code}-flashcards`), [config.code]);
+  const [url, setUrl] = useState("");
+  const [lesson, setLesson] = useState<VideoLesson | null>(null);
+  const [known, setKnown] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [savedMessage, setSavedMessage] = useState("");
+
+  const newCards = lesson?.vocab.filter((item) => !known.has(cardKey(item))) ?? [];
+
+  async function analyzeVideo(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError("");
+    setSavedMessage("");
+    setLesson(null);
+    setKnown(new Set());
+
+    try {
+      const response = await fetch("/api/video/process", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "Could not analyze this video.");
+      }
+
+      setLesson(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function saveToDeck() {
+    if (!lesson || newCards.length === 0) return;
+
+    const category = getOrCreateImportCategory(storage);
+    const existing = storage.getFlashcards();
+    const existingKeys = new Set(existing.map((card) => normalizedCardKey(card.word, card.translation)));
+    const today = new Date().toISOString().split("T")[0];
+
+    const cardsToAdd: Flashcard[] = newCards
+      .filter((item) => !existingKeys.has(normalizedCardKey(item.word, item.meaning)))
+      .map((item) => ({
+        id: uuidv4(),
+        word: item.word,
+        pronunciation: item.pronunciation || undefined,
+        translation: item.meaning,
+        categoryId: category.id,
+        difficulty: item.level === "slang" || item.level === "phrase" ? 2 : 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        reviewHistory: [],
+        readingReviewLevel: 0,
+        readingNextReviewDate: today,
+        readingDifficulty: 1,
+        listeningReviewLevel: 0,
+        listeningNextReviewDate: today,
+        listeningDifficulty: 1,
+        speakingReviewLevel: 0,
+        speakingNextReviewDate: today,
+        speakingDifficulty: 1,
+      }));
+
+    storage.saveFlashcards([...existing, ...cardsToAdd]);
+    setSavedMessage(
+      cardsToAdd.length
+        ? `Saved ${cardsToAdd.length} cards to ${config.name} review.`
+        : "Those cards are already in your deck.",
+    );
+  }
+
+  return (
+    <div className="min-h-[100dvh] bg-gray-50 dark:bg-gray-900">
+      <div className="mx-auto max-w-3xl px-4 py-6">
+        <Link
+          href="/"
+          className="mb-5 inline-flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to ChindoSpeak
+        </Link>
+
+        <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="mb-5 flex items-start gap-3">
+            <div
+              className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl text-white"
+              style={{ backgroundColor: config.theme.primary }}
+            >
+              <Clapperboard className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Learn from video
+              </p>
+              <h1 className="text-2xl font-bold text-gray-950 dark:text-white">
+                Turn a short clip into ChindoSpeak cards
+              </h1>
+              <p className="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+                Paste a Reel, TikTok, or Short. ChindoSpeak will transcribe it, clean up subtitles, pull out useful phrases, and save the words you actually want to review.
+              </p>
+            </div>
+          </div>
+
+          <form onSubmit={analyzeVideo} className="flex flex-col gap-3 sm:flex-row">
+            <input
+              type="url"
+              required
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder="https://www.instagram.com/reel/..."
+              className="min-h-12 flex-1 rounded-xl border border-gray-300 bg-white px-4 text-base text-gray-900 outline-none focus:ring-2 dark:border-gray-600 dark:bg-gray-900 dark:text-white"
+              style={{ boxShadow: "none" }}
+            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-5 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-60"
+              style={{ backgroundColor: config.theme.primary }}
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+              {loading ? "Analyzing" : "Analyze"}
+            </button>
+          </form>
+
+          {loading ? (
+            <p className="mt-4 rounded-xl bg-gray-100 p-3 text-sm text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+              Downloading the clip, reading on-screen subtitles, transcribing audio, and building cards. This usually takes 30-60 seconds.
+            </p>
+          ) : null}
+
+          {error ? (
+            <p className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+              {error}
+            </p>
+          ) : null}
+        </section>
+
+        {lesson ? (
+          <section className="mt-5 space-y-5">
+            <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium text-gray-500 dark:text-gray-400">Detected language</p>
+                  <h2 className="text-xl font-bold text-gray-950 dark:text-white">{lesson.language || lesson.detectedLang}</h2>
+                  <p className="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-300">{lesson.summary}</p>
+                </div>
+                <div className="rounded-xl bg-gray-100 p-3 text-sm text-gray-700 dark:bg-gray-900 dark:text-gray-200">
+                  <p><strong>{newCards.length}</strong> new</p>
+                  <p><strong>{lesson.vocab.length - newCards.length}</strong> marked known</p>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+                <button
+                  type="button"
+                  onClick={saveToDeck}
+                  disabled={newCards.length === 0}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl px-4 py-3 font-semibold text-white transition disabled:cursor-not-allowed disabled:opacity-50"
+                  style={{ backgroundColor: config.theme.primary }}
+                >
+                  <Save className="h-4 w-4" />
+                  Save {newCards.length} to {config.name}
+                </button>
+                <Link
+                  href="/review"
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border border-gray-300 px-4 py-3 font-semibold text-gray-800 dark:border-gray-600 dark:text-white"
+                >
+                  <BookOpen className="h-4 w-4" />
+                  Review deck
+                </Link>
+              </div>
+
+              {savedMessage ? (
+                <p className="mt-3 rounded-xl bg-emerald-50 p-3 text-sm font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200">
+                  {savedMessage}
+                </p>
+              ) : null}
+            </div>
+
+            <Panel title="Phrase drill">
+              <div className="space-y-3">
+                {lesson.quiz.slice(0, 5).map((item, index) => (
+                  <details key={`${item.question}-${index}`} className="rounded-xl border border-gray-200 p-4 dark:border-gray-700">
+                    <summary className="cursor-pointer text-sm font-semibold text-gray-900 dark:text-white">
+                      {index + 1}. {item.question}
+                    </summary>
+                    <div className="mt-3 space-y-2 text-sm text-gray-600 dark:text-gray-300">
+                      {item.choices.map((choice) => (
+                        <p key={choice} className={choice === item.answer ? "font-semibold text-emerald-700 dark:text-emerald-300" : ""}>
+                          {choice === item.answer ? "✓ " : ""}{choice}
+                        </p>
+                      ))}
+                      <p>{item.explanation}</p>
+                    </div>
+                  </details>
+                ))}
+              </div>
+            </Panel>
+
+            {lesson.speakingChallenge ? (
+              <Panel title="Speaking prompt">
+                <p className="text-sm leading-6 text-gray-700 dark:text-gray-200">{lesson.speakingChallenge.prompt}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {lesson.speakingChallenge.keywords.map((keyword) => (
+                    <span key={keyword} className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-700 dark:bg-gray-900 dark:text-gray-200">
+                      {keyword}
+                    </span>
+                  ))}
+                </div>
+              </Panel>
+            ) : null}
+
+            <Panel title="Cards">
+              <div className="grid gap-3">
+                {lesson.vocab.map((item, index) => {
+                  const isKnown = known.has(cardKey(item));
+                  return (
+                    <article
+                      key={`${item.word}-${index}`}
+                      className={`rounded-xl border p-4 transition ${
+                        isKnown
+                          ? "border-gray-200 bg-gray-50 opacity-70 dark:border-gray-700 dark:bg-gray-900"
+                          : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <div className="flex flex-wrap items-baseline gap-2">
+                            <h3 className="text-xl font-bold text-gray-950 dark:text-white">{item.word}</h3>
+                            {item.pronunciation ? (
+                              <span className="text-sm text-gray-500 dark:text-gray-400">{item.pronunciation}</span>
+                            ) : null}
+                            {item.level ? (
+                              <span className="rounded-full bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-500 dark:bg-gray-900 dark:text-gray-300">
+                                {item.level}
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 font-medium text-gray-800 dark:text-gray-100">{item.meaning}</p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setSavedMessage("");
+                            setKnown((current) => {
+                              const next = new Set(current);
+                              const key = cardKey(item);
+                              if (next.has(key)) next.delete(key);
+                              else next.add(key);
+                              return next;
+                            });
+                          }}
+                          className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-semibold ${
+                            isKnown
+                              ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200"
+                              : "bg-gray-100 text-gray-600 dark:bg-gray-900 dark:text-gray-300"
+                          }`}
+                        >
+                          {isKnown ? <Check className="h-3 w-3" /> : null}
+                          {isKnown ? "Known" : "New"}
+                        </button>
+                      </div>
+                      {item.sourcePhrase ? (
+                        <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">From video: {item.sourcePhrase}</p>
+                      ) : null}
+                      {item.example ? (
+                        <p className="mt-2 text-sm italic text-gray-600 dark:text-gray-300">{item.example}</p>
+                      ) : null}
+                      {item.note || item.usefulness ? (
+                        <p className="mt-2 text-xs leading-5 text-gray-500 dark:text-gray-400">
+                          {[item.note, item.usefulness].filter(Boolean).join(" · ")}
+                        </p>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            </Panel>
+
+            <Panel title="Transcript">
+              <p className="text-base leading-7 text-gray-900 dark:text-white">{lesson.cleanTranscript || lesson.transcript}</p>
+              {lesson.transcriptNotes ? (
+                <p className="mt-3 rounded-xl bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-100">
+                  {lesson.transcriptNotes}
+                </p>
+              ) : null}
+              <p className="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">{lesson.translation}</p>
+            </Panel>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <h2 className="mb-4 text-sm font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function getOrCreateImportCategory(storage: UnifiedLocalStorage): Category {
+  const categories = storage.getCategories();
+  const existing = categories.find((category) => category.name === IMPORT_CATEGORY);
+  if (existing) return existing;
+
+  const category: Category = {
+    id: uuidv4(),
+    name: IMPORT_CATEGORY,
+    color: "#7C3AED",
+    createdAt: new Date(),
+  };
+  storage.saveCategories([...categories, category]);
+  return category;
+}
+
+function cardKey(item: VocabItem) {
+  return normalizedCardKey(item.word, item.meaning);
+}
+
+function normalizedCardKey(word: string, meaning: string) {
+  return `${word.trim().toLowerCase()}::${meaning.trim().toLowerCase()}`;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,16 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
-
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals"),
-];
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  {
+    rules: {
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/immutability": "off",
+      "react/no-unescaped-entities": "off",
+    },
+  },
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
+]);
 
 export default eslintConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^1.14.0",
         "msedge-tts": "^2.0.5",
         "next": "16.2.6",
+        "openai": "^6.37.0",
         "pinyin": "^3.0.0-alpha.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -5944,6 +5945,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openai": {
+      "version": "6.37.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.37.0.tgz",
+      "integrity": "sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8010,7 +8032,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^1.14.0",
     "msedge-tts": "^2.0.5",
     "next": "16.2.6",
+    "openai": "^6.37.0",
     "pinyin": "^3.0.0-alpha.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
Adds a Learn from Video flow that turns short-form video URLs into cleaned transcripts, phrase drills, speaking prompts, and ChindoSpeak flashcards.\n\nWhat changed:\n- Added /video page for analyzing Reels, TikToks, and Shorts\n- Added /api/video/process using yt-dlp, ffmpeg, Whisper, GPT-4o-mini vision OCR, and GPT-4o-mini lesson generation\n- Saves selected new cards into the active ChindoSpeak language deck under Video Imports\n- Added nav/home entry points and setup docs\n\nVerified:\n- npm run type-check\n- localhost /video renders\n- API validation responds correctly